### PR TITLE
Refactor: 관리자페이지 접근 불가 설정

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -6,6 +6,7 @@ import Image from "next/image";
 import Header from "@/components/common/Header";
 import Card from "@/components/common/Card";
 import Button from "@/components/common/Button";
+import AdminGuard from "@/components/common/AdminGuard";
 import type { AdminRole } from "@/types";
 
 export default function AdminPage() {
@@ -77,75 +78,77 @@ export default function AdminPage() {
   );
 
   return (
-    <div className="relative flex min-h-screen w-full flex-col">
-      <Header
-        showLogout
-        variant="page"
-        rightContent={
-          <div className="flex flex-1 justify-end items-center gap-4 sm:gap-6">
-            <Link
-              className="text-sm font-medium hover:text-primary transition-colors"
-              href="/rooms"
-            >
-              회의실 예약
-            </Link>
-            <div className="relative flex items-center justify-center size-10 rounded-full overflow-hidden">
-              <Image
-                src="/logo.png"
-                alt="사용자 프로필"
-                width={40}
-                height={40}
-                className="h-full w-full object-cover"
-              />
+    <AdminGuard>
+      <div className="relative flex min-h-screen w-full flex-col">
+        <Header
+          showLogout
+          variant="page"
+          rightContent={
+            <div className="flex flex-1 justify-end items-center gap-4 sm:gap-6">
+              <Link
+                className="text-sm font-medium hover:text-primary transition-colors"
+                href="/rooms"
+              >
+                회의실 예약
+              </Link>
+              <div className="relative flex items-center justify-center size-10 rounded-full overflow-hidden">
+                <Image
+                  src="/logo.png"
+                  alt="사용자 프로필"
+                  width={40}
+                  height={40}
+                  className="h-full w-full object-cover"
+                />
+              </div>
             </div>
-          </div>
-        }
-      />
-      <main className="flex flex-1 justify-center px-4 sm:px-8 md:px-12 lg:px-20 xl:px-40 py-5">
-        <div className="flex w-full max-w-7xl flex-col">
-          <main className="flex flex-col gap-10 mt-8">
-            <div className="px-2">
-              <h2 className="text-4xl font-black tracking-tighter">관리자 페이지</h2>
-              <p className="mt-2 text-text-light-secondary dark:text-dark-secondary">
-                Say Ye 시스템을 관리하고 설정을 변경합니다.
-              </p>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 px-2">
-              {visibleMenus.map((menu) => (
-                <Card key={menu.title} className="flex flex-col gap-4 hover:shadow-lg transition-shadow">
-                  <div className="flex items-center gap-3">
-                    <div className="flex items-center justify-center size-10 rounded-lg bg-primary-light p-1.5">
-                      <Image
-                        src="/logo.png"
-                        alt={menu.title}
-                        width={40}
-                        height={40}
-                        className="h-full w-full object-contain"
-                      />
+          }
+        />
+        <main className="flex flex-1 justify-center px-4 sm:px-8 md:px-12 lg:px-20 xl:px-40 py-5">
+          <div className="flex w-full max-w-7xl flex-col">
+            <main className="flex flex-col gap-10 mt-8">
+              <div className="px-2">
+                <h2 className="text-4xl font-black tracking-tighter">관리자 페이지</h2>
+                <p className="mt-2 text-text-light-secondary dark:text-dark-secondary">
+                  Say Ye 시스템을 관리하고 설정을 변경합니다.
+                </p>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 px-2">
+                {visibleMenus.map((menu) => (
+                  <Card key={menu.title} className="flex flex-col gap-4 hover:shadow-lg transition-shadow">
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center justify-center size-10 rounded-lg bg-primary-light p-1.5">
+                        <Image
+                          src="/logo.png"
+                          alt={menu.title}
+                          width={40}
+                          height={40}
+                          className="h-full w-full object-contain"
+                        />
+                      </div>
+                      <h3 className="text-lg font-bold">{menu.title}</h3>
                     </div>
-                    <h3 className="text-lg font-bold">{menu.title}</h3>
-                  </div>
-                  <p className="text-sm text-text-light-secondary dark:text-dark-secondary">
-                    {menu.description}
-                  </p>
-                  {menu.active ? (
-                    <Link href={menu.href} className="mt-auto">
-                      <Button variant="primary" fullWidth>
-                        <span>{menu.title} 바로가기</span>
+                    <p className="text-sm text-text-light-secondary dark:text-dark-secondary">
+                      {menu.description}
+                    </p>
+                    {menu.active ? (
+                      <Link href={menu.href} className="mt-auto">
+                        <Button variant="primary" fullWidth>
+                          <span>{menu.title} 바로가기</span>
+                        </Button>
+                      </Link>
+                    ) : (
+                      <Button variant="secondary" fullWidth disabled>
+                        <span>{menu.title}</span>
                       </Button>
-                    </Link>
-                  ) : (
-                    <Button variant="secondary" fullWidth disabled>
-                      <span>{menu.title}</span>
-                    </Button>
-                  )}
-                </Card>
-              ))}
-            </div>
-          </main>
-        </div>
-      </main>
-    </div>
+                    )}
+                  </Card>
+                ))}
+              </div>
+            </main>
+          </div>
+        </main>
+      </div>
+    </AdminGuard>
   );
 }
 

--- a/app/admin/reservations/page.tsx
+++ b/app/admin/reservations/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import Header from "@/components/common/Header";
 import Card from "@/components/common/Card";
 import Button from "@/components/common/Button";
+import AdminGuard from "@/components/common/AdminGuard";
 import { reservationApi } from "@/lib/api/reservation";
 import type { ReservationAdminResponse, PaginatedResponse } from "@/types";
 
@@ -51,88 +52,90 @@ export default function AdminReservationsPage() {
   }
 
   return (
-    <div className="relative flex min-h-screen w-full flex-col">
-      <Header showLogout />
-      <main className="flex-1 w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-4xl font-black tracking-tight mb-8">예약 현황 관리</h1>
+    <AdminGuard>
+      <div className="relative flex min-h-screen w-full flex-col">
+        <Header showLogout />
+        <main className="flex-1 w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <h1 className="text-4xl font-black tracking-tight mb-8">예약 현황 관리</h1>
 
-        <div className="flex flex-col gap-4 mb-8">
-          {reservations.length === 0 ? (
-            <Card>
-              <p className="text-center text-text-light-secondary dark:text-text-dark-secondary">
-                예약 내역이 없습니다.
-              </p>
-            </Card>
-          ) : (
-            reservations.map((reservation) => (
-              <Card key={reservation.id}>
-                <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
-                  <div className="flex-1">
-                    <h3 className="text-lg font-bold mb-2">{reservation.roomName}</h3>
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm text-text-light-secondary dark:text-text-dark-secondary">
-                      <p>
-                        <span className="font-semibold">강의:</span> {reservation.courseName}
-                      </p>
-                      <p>
-                        <span className="font-semibold">예약자:</span> {reservation.userName}
-                      </p>
-                      <p>
-                        <span className="font-semibold">연락처:</span> {reservation.phoneLastNumber}
-                      </p>
-                      <p>
-                        <span className="font-semibold">상태:</span> {reservation.status}
-                      </p>
-                      <p>
-                        <span className="font-semibold">날짜:</span>{" "}
-                        {new Date(reservation.reservationDate).toLocaleDateString("ko-KR")}
-                      </p>
-                      <p>
-                        <span className="font-semibold">시간:</span>{" "}
-                        {reservation.startTime.split(":").slice(0, 2).join(":")} ~{" "}
-                        {reservation.endTime.split(":").slice(0, 2).join(":")}
-                      </p>
-                      <p>
-                        <span className="font-semibold">생성일:</span>{" "}
-                        {new Date(reservation.createdAt).toLocaleString("ko-KR")}
-                      </p>
-                    </div>
-                  </div>
-                  <Button
-                    variant="secondary"
-                    onClick={() => handleDelete(reservation.id)}
-                    size="sm"
-                  >
-                    삭제
-                  </Button>
-                </div>
+          <div className="flex flex-col gap-4 mb-8">
+            {reservations.length === 0 ? (
+              <Card>
+                <p className="text-center text-text-light-secondary dark:text-text-dark-secondary">
+                  예약 내역이 없습니다.
+                </p>
               </Card>
-            ))
-          )}
-        </div>
-
-        {totalPages > 1 && (
-          <div className="flex justify-center gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              disabled={page === 1}
-            >
-              이전
-            </Button>
-            <span className="flex items-center px-4">
-              {page} / {totalPages}
-            </span>
-            <Button
-              variant="outline"
-              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-              disabled={page === totalPages}
-            >
-              다음
-            </Button>
+            ) : (
+              reservations.map((reservation) => (
+                <Card key={reservation.id}>
+                  <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+                    <div className="flex-1">
+                      <h3 className="text-lg font-bold mb-2">{reservation.roomName}</h3>
+                      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm text-text-light-secondary dark:text-text-dark-secondary">
+                        <p>
+                          <span className="font-semibold">강의:</span> {reservation.courseName}
+                        </p>
+                        <p>
+                          <span className="font-semibold">예약자:</span> {reservation.userName}
+                        </p>
+                        <p>
+                          <span className="font-semibold">연락처:</span> {reservation.phoneLastNumber}
+                        </p>
+                        <p>
+                          <span className="font-semibold">상태:</span> {reservation.status}
+                        </p>
+                        <p>
+                          <span className="font-semibold">날짜:</span>{" "}
+                          {new Date(reservation.reservationDate).toLocaleDateString("ko-KR")}
+                        </p>
+                        <p>
+                          <span className="font-semibold">시간:</span>{" "}
+                          {reservation.startTime.split(":").slice(0, 2).join(":")} ~{" "}
+                          {reservation.endTime.split(":").slice(0, 2).join(":")}
+                        </p>
+                        <p>
+                          <span className="font-semibold">생성일:</span>{" "}
+                          {new Date(reservation.createdAt).toLocaleString("ko-KR")}
+                        </p>
+                      </div>
+                    </div>
+                    <Button
+                      variant="secondary"
+                      onClick={() => handleDelete(reservation.id)}
+                      size="sm"
+                    >
+                      삭제
+                    </Button>
+                  </div>
+                </Card>
+              ))
+            )}
           </div>
-        )}
-      </main>
-    </div>
+
+          {totalPages > 1 && (
+            <div className="flex justify-center gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page === 1}
+              >
+                이전
+              </Button>
+              <span className="flex items-center px-4">
+                {page} / {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+              >
+                다음
+              </Button>
+            </div>
+          )}
+        </main>
+      </div>
+    </AdminGuard>
   );
 }
 

--- a/app/admin/rooms/page.tsx
+++ b/app/admin/rooms/page.tsx
@@ -5,6 +5,7 @@ import Header from "@/components/common/Header";
 import Button from "@/components/common/Button";
 import Card from "@/components/common/Card";
 import Input from "@/components/common/Input";
+import AdminGuard from "@/components/common/AdminGuard";
 import { roomApi } from "@/lib/api/room";
 import type { RoomResponse, RoomRequest } from "@/types";
 
@@ -90,117 +91,119 @@ export default function AdminRoomsPage() {
   }
 
   return (
-    <div className="relative flex min-h-screen w-full flex-col">
-      <Header showLogout />
-      <main className="flex-1 w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="flex justify-between items-center mb-8">
-          <h1 className="text-4xl font-black tracking-tight">회의실 관리</h1>
-          <Button onClick={() => setShowForm(!showForm)}>
-            {showForm ? "취소" : "새 회의실 추가"}
-          </Button>
-        </div>
+    <AdminGuard>
+      <div className="relative flex min-h-screen w-full flex-col">
+        <Header showLogout />
+        <main className="flex-1 w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="flex justify-between items-center mb-8">
+            <h1 className="text-4xl font-black tracking-tight">회의실 관리</h1>
+            <Button onClick={() => setShowForm(!showForm)}>
+              {showForm ? "취소" : "새 회의실 추가"}
+            </Button>
+          </div>
 
-        {showForm && (
-          <Card className="mb-8">
-            <h2 className="text-2xl font-bold mb-4">
-              {editingRoom ? "회의실 수정" : "새 회의실 추가"}
-            </h2>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-              <Input
-                label="회의실 이름"
-                value={formData.roomName}
-                onChange={(e) =>
-                  setFormData({ ...formData, roomName: e.target.value })
-                }
-                required
-              />
-              <Input
-                label="위치 (선택)"
-                type="number"
-                value={formData.location || ""}
-                onChange={(e) =>
-                  setFormData({
-                    ...formData,
-                    location: e.target.value ? Number(e.target.value) : undefined,
-                  })
-                }
-              />
-              <Input
-                label="수용 인원"
-                type="number"
-                min="1"
-                value={formData.capacity}
-                onChange={(e) =>
-                  setFormData({ ...formData, capacity: Number(e.target.value) })
-                }
-                required
-              />
-              <Input
-                label="설명 (선택)"
-                value={formData.description || ""}
-                onChange={(e) =>
-                  setFormData({ ...formData, description: e.target.value })
-                }
-              />
-              <div className="flex gap-2">
-                <Button type="submit" variant="primary">
-                  {editingRoom ? "수정" : "생성"}
-                </Button>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={() => {
-                    setShowForm(false);
-                    setEditingRoom(null);
+          {showForm && (
+            <Card className="mb-8">
+              <h2 className="text-2xl font-bold mb-4">
+                {editingRoom ? "회의실 수정" : "새 회의실 추가"}
+              </h2>
+              <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+                <Input
+                  label="회의실 이름"
+                  value={formData.roomName}
+                  onChange={(e) =>
+                    setFormData({ ...formData, roomName: e.target.value })
+                  }
+                  required
+                />
+                <Input
+                  label="위치 (선택)"
+                  type="number"
+                  value={formData.location || ""}
+                  onChange={(e) =>
                     setFormData({
-                      roomName: "",
-                      location: undefined,
-                      capacity: 1,
-                      description: "",
-                    });
-                  }}
-                >
-                  취소
-                </Button>
-              </div>
-            </form>
-          </Card>
-        )}
+                      ...formData,
+                      location: e.target.value ? Number(e.target.value) : undefined,
+                    })
+                  }
+                />
+                <Input
+                  label="수용 인원"
+                  type="number"
+                  min="1"
+                  value={formData.capacity}
+                  onChange={(e) =>
+                    setFormData({ ...formData, capacity: Number(e.target.value) })
+                  }
+                  required
+                />
+                <Input
+                  label="설명 (선택)"
+                  value={formData.description || ""}
+                  onChange={(e) =>
+                    setFormData({ ...formData, description: e.target.value })
+                  }
+                />
+                <div className="flex gap-2">
+                  <Button type="submit" variant="primary">
+                    {editingRoom ? "수정" : "생성"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => {
+                      setShowForm(false);
+                      setEditingRoom(null);
+                      setFormData({
+                        roomName: "",
+                        location: undefined,
+                        capacity: 1,
+                        description: "",
+                      });
+                    }}
+                  >
+                    취소
+                  </Button>
+                </div>
+              </form>
+            </Card>
+          )}
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {rooms.map((room) => (
-            <Card key={room.id}>
-              <div className="flex flex-col gap-4">
-                <div>
-                  <h3 className="text-xl font-bold mb-2">{room.roomName}</h3>
-                  <div className="flex flex-col gap-1 text-sm text-text-light-secondary dark:text-text-dark-secondary">
-                    {room.location && <p>위치: {room.location}층</p>}
-                    <p>수용 인원: {room.capacity}명</p>
-                    {room.description && <p>설명: {room.description}</p>}
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {rooms.map((room) => (
+              <Card key={room.id}>
+                <div className="flex flex-col gap-4">
+                  <div>
+                    <h3 className="text-xl font-bold mb-2">{room.roomName}</h3>
+                    <div className="flex flex-col gap-1 text-sm text-text-light-secondary dark:text-text-dark-secondary">
+                      {room.location && <p>위치: {room.location}층</p>}
+                      <p>수용 인원: {room.capacity}명</p>
+                      {room.description && <p>설명: {room.description}</p>}
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      onClick={() => handleEdit(room)}
+                      size="sm"
+                    >
+                      수정
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      onClick={() => handleDelete(room.id)}
+                      size="sm"
+                    >
+                      삭제
+                    </Button>
                   </div>
                 </div>
-                <div className="flex gap-2">
-                  <Button
-                    variant="outline"
-                    onClick={() => handleEdit(room)}
-                    size="sm"
-                  >
-                    수정
-                  </Button>
-                  <Button
-                    variant="secondary"
-                    onClick={() => handleDelete(room.id)}
-                    size="sm"
-                  >
-                    삭제
-                  </Button>
-                </div>
-              </div>
-            </Card>
-          ))}
-        </div>
-      </main>
-    </div>
+              </Card>
+            ))}
+          </div>
+        </main>
+      </div>
+    </AdminGuard>
   );
 }
 

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -6,6 +6,7 @@ import Header from "@/components/common/Header";
 import Card from "@/components/common/Card";
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
+import AdminGuard from "@/components/common/AdminGuard";
 import { adminApi } from "@/lib/api/admin";
 import { authApi } from "@/lib/api/auth";
 import type { AdminResponse, SignupRequest } from "@/types";
@@ -70,88 +71,90 @@ export default function AdminUsersPage() {
   }
 
   return (
-    <div className="relative flex min-h-screen w-full flex-col">
-      <Header showLogout />
-      <main className="flex-1 w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <h1 className="text-4xl font-black tracking-tight mb-8">사용자 관리</h1>
+    <AdminGuard>
+      <div className="relative flex min-h-screen w-full flex-col">
+        <Header showLogout />
+        <main className="flex-1 w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <h1 className="text-4xl font-black tracking-tight mb-8">사용자 관리</h1>
 
-        <Card className="mb-8">
-          <div className="flex flex-col gap-4">
-            <h2 className="text-xl font-bold">관리자 추가</h2>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
-              <Input
-                label="ID"
-                value={newAdmin.userId}
-                onChange={(e) => setNewAdmin({ ...newAdmin, userId: e.target.value })}
-                placeholder="admin id"
-                required
-              />
-              <Input
-                label="비밀번호"
-                type="password"
-                value={newAdmin.password}
-                onChange={(e) => setNewAdmin({ ...newAdmin, password: e.target.value })}
-                placeholder="비밀번호"
-                required
-              />
-              <Input
-                label="이름"
-                value={newAdmin.name}
-                onChange={(e) => setNewAdmin({ ...newAdmin, name: e.target.value })}
-                placeholder="이름"
-                required
-              />
-              <Input
-                label="이메일"
-                type="email"
-                value={newAdmin.email}
-                onChange={(e) => setNewAdmin({ ...newAdmin, email: e.target.value })}
-                placeholder="email@example.com"
-                required
-              />
-            </div>
-            <div className="flex justify-end">
-              <Button variant="primary" onClick={handleCreate}>
-                관리자 추가
-              </Button>
-            </div>
-          </div>
-        </Card>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {admins.map((admin) => (
-            <Card key={admin.id}>
-              <div className="flex flex-col gap-4">
-                <div className="flex items-center gap-3">
-                  <div className="flex-shrink-0 size-12 rounded-full overflow-hidden">
-                    <Image
-                      src="/logo.png"
-                      alt={`${admin.name} 프로필`}
-                      width={48}
-                      height={48}
-                      className="h-full w-full object-cover"
-                    />
-                  </div>
-                  <div className="flex-1">
-                    <h3 className="text-xl font-bold">{admin.name}</h3>
-                  </div>
-                </div>
-                <div className="flex flex-col gap-1 text-sm text-text-light-secondary dark:text-text-dark-secondary">
-                  <p>ID: {admin.userId}</p>
-                  <p>이메일: {admin.email}</p>
-                  <p>역할: {admin.role}</p>
-                </div>
-                <div className="flex gap-2">
-                  <Button variant="secondary" onClick={() => handleDelete(admin.id)} size="sm">
-                    삭제
-                  </Button>
-                </div>
+          <Card className="mb-8">
+            <div className="flex flex-col gap-4">
+              <h2 className="text-xl font-bold">관리자 추가</h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+                <Input
+                  label="ID"
+                  value={newAdmin.userId}
+                  onChange={(e) => setNewAdmin({ ...newAdmin, userId: e.target.value })}
+                  placeholder="admin id"
+                  required
+                />
+                <Input
+                  label="비밀번호"
+                  type="password"
+                  value={newAdmin.password}
+                  onChange={(e) => setNewAdmin({ ...newAdmin, password: e.target.value })}
+                  placeholder="비밀번호"
+                  required
+                />
+                <Input
+                  label="이름"
+                  value={newAdmin.name}
+                  onChange={(e) => setNewAdmin({ ...newAdmin, name: e.target.value })}
+                  placeholder="이름"
+                  required
+                />
+                <Input
+                  label="이메일"
+                  type="email"
+                  value={newAdmin.email}
+                  onChange={(e) => setNewAdmin({ ...newAdmin, email: e.target.value })}
+                  placeholder="email@example.com"
+                  required
+                />
               </div>
-            </Card>
-          ))}
-        </div>
-      </main>
-    </div>
+              <div className="flex justify-end">
+                <Button variant="primary" onClick={handleCreate}>
+                  관리자 추가
+                </Button>
+              </div>
+            </div>
+          </Card>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {admins.map((admin) => (
+              <Card key={admin.id}>
+                <div className="flex flex-col gap-4">
+                  <div className="flex items-center gap-3">
+                    <div className="flex-shrink-0 size-12 rounded-full overflow-hidden">
+                      <Image
+                        src="/logo.png"
+                        alt={`${admin.name} 프로필`}
+                        width={48}
+                        height={48}
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <h3 className="text-xl font-bold">{admin.name}</h3>
+                    </div>
+                  </div>
+                  <div className="flex flex-col gap-1 text-sm text-text-light-secondary dark:text-text-dark-secondary">
+                    <p>ID: {admin.userId}</p>
+                    <p>이메일: {admin.email}</p>
+                    <p>역할: {admin.role}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button variant="secondary" onClick={() => handleDelete(admin.id)} size="sm">
+                      삭제
+                    </Button>
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        </main>
+      </div>
+    </AdminGuard>
   );
 }
 

--- a/components/common/AdminGuard.tsx
+++ b/components/common/AdminGuard.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { isAdmin } from "@/lib/utils/jwt";
+
+interface AdminGuardProps {
+    children: React.ReactNode;
+}
+
+/**
+ * 관리자 전용 페이지 접근 제어 컴포넌트
+ * MASTER 또는 ADMIN 역할이 아닌 경우 홈 페이지로 리다이렉트
+ */
+export default function AdminGuard({ children }: AdminGuardProps) {
+    const router = useRouter();
+    const [isAuthorized, setIsAuthorized] = useState(false);
+    const hasChecked = useRef(false);
+
+    useEffect(() => {
+        // 이미 확인했으면 다시 실행하지 않음
+        if (hasChecked.current) return;
+
+        const checkAdminAccess = () => {
+            const adminStatus = isAdmin();
+
+            if (!adminStatus) {
+                // 관리자가 아닌 경우 홈 페이지로 리다이렉트
+                hasChecked.current = true;
+                alert("관리자만 접근할 수 있는 페이지입니다.");
+                router.push("/");
+                return;
+            }
+
+            hasChecked.current = true;
+            setIsAuthorized(true);
+        };
+
+        checkAdminAccess();
+    }, [router]);
+
+    // 권한 확인 중에는 아무것도 렌더링하지 않음
+    if (!isAuthorized) {
+        return (
+            <div className="flex items-center justify-center min-h-screen">
+                <div className="text-center">
+                    <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+                    <p className="text-sm text-gray-500">권한 확인 중...</p>
+                </div>
+            </div>
+        );
+    }
+
+    return <>{children}</>;
+}

--- a/components/common/Header.tsx
+++ b/components/common/Header.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { ReactNode, useEffect, useState } from "react";
+import { isAdmin } from "@/lib/utils/jwt";
 
 interface HeaderProps {
   showLogout?: boolean;
@@ -20,6 +21,7 @@ export default function Header({
 }: HeaderProps) {
   const pathname = usePathname();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isAdminUser, setIsAdminUser] = useState(false);
 
   useEffect(() => {
     // 클라이언트에서만 토큰 확인
@@ -27,6 +29,10 @@ export default function Header({
       if (typeof window === "undefined") return;
       const token = localStorage.getItem("accessToken");
       setIsLoggedIn(Boolean(token));
+
+      // 관리자 여부 확인
+      const adminStatus = isAdmin();
+      setIsAdminUser(adminStatus);
     };
 
     checkAuth();
@@ -180,7 +186,7 @@ export default function Header({
                     회의실 예약
                   </Link>
                 )}
-                {pathname !== "/rooms/reserve" && pathname !== "/rooms/select" && (
+                {isAdminUser && pathname !== "/rooms/reserve" && pathname !== "/rooms/select" && (
                   <Link
                     href="/admin"
                     className={`text-sm font-medium transition-colors ${pathname === "/admin"


### PR DESCRIPTION
### 작업 내용
* 로그인하지 않은 일반 사용자가 (수강생) '내 예약 현황' 페이지에 접속하면 상단에 노출되어 있던 관리자 페이지 탭을 통해 해당 페이지로 이동할 수 있었습니다.
<img width="500" height="500" alt="스크린샷 2025-12-21 오후 12 31 33" src="https://github.com/user-attachments/assets/2c860739-a718-481f-873a-7c2714dc9b61" />

* 로그인하지 않은 상태이거나 JWT role이 MASTER / ADMIN이 아닌 경우에는 해당 탭을 제거했습니다.
<img width="500" height="500" alt="스크린샷 2025-12-21 오후 12 34 01" src="https://github.com/user-attachments/assets/67996b08-020e-4b3a-ab1d-fa10eb1d12dd" />

* 로그인하지 않은 상태에서 URL path를 직접 입력해 접속하면 모든 관리자 페이지를 접속할 수 있었습니다.
<img width="500" height="500" alt="스크린샷 2025-12-21 오후 12 32 54" src="https://github.com/user-attachments/assets/53a63e21-8773-4294-a9dc-4e698fcf0da7" />
<img width="500" height="500" alt="스크린샷 2025-12-21 오후 12 32 24" src="https://github.com/user-attachments/assets/0c812e2a-d2aa-4526-9765-703a55cb3692" />

* 동일하게 로그인하지 않은 상태이거나 JWT role이 MASTER / ADMIN이 아닌 경우에는 home 화면으로 리다이렉트 시켰습니다.
<img width="500" height="500" alt="스크린샷 2025-12-21 오후 12 34 18" src="https://github.com/user-attachments/assets/61df1a3e-7488-4f0e-8844-9de078573f50" />


