### PR TITLE
refactor/ 회의실 예약 시간 선택 로직 및 현황 페이지, 예약 현황 관리 페이지 UI/UX 개선 

### DIFF
--- a/app/admin/reservations/page.tsx
+++ b/app/admin/reservations/page.tsx
@@ -1,29 +1,52 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import Header from "@/components/common/Header";
 import Card from "@/components/common/Card";
 import Button from "@/components/common/Button";
+import Select from "@/components/common/Select";
+import Input from "@/components/common/Input";
 import AdminGuard from "@/components/common/AdminGuard";
 import { reservationApi } from "@/lib/api/reservation";
-import type { ReservationAdminResponse, PaginatedResponse } from "@/types";
+import { roomApi } from "@/lib/api/room";
+import type { ReservationAdminResponse, PaginatedResponse, RoomResponse } from "@/types";
 
 export default function AdminReservationsPage() {
-  const [reservations, setReservations] = useState<ReservationAdminResponse[]>([]);
+  const [rawReservations, setRawReservations] = useState<ReservationAdminResponse[]>([]);
+  const [rooms, setRooms] = useState<RoomResponse[]>([]);
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [loading, setLoading] = useState(true);
+  const [filters, setFilters] = useState({
+    roomId: "",
+    status: "",
+    userName: "",
+  });
+
+  useEffect(() => {
+    fetchRooms();
+  }, []);
 
   useEffect(() => {
     fetchReservations();
   }, [page]);
+
+  const fetchRooms = async () => {
+    try {
+      const data = await roomApi.getRooms();
+      setRooms(data);
+    } catch (error) {
+      console.error("회의실 조회 실패:", error);
+    }
+  };
 
   const fetchReservations = async () => {
     setLoading(true);
     try {
       const data: PaginatedResponse<ReservationAdminResponse> =
         await reservationApi.getAdminReservations(page);
-      setReservations(data.content);
+      
+      setRawReservations(data.content);
       setTotalPages(data.totalPages);
     } catch (error) {
       console.error("예약 목록 조회 실패:", error);
@@ -32,18 +55,36 @@ export default function AdminReservationsPage() {
     }
   };
 
+  const filteredReservations = useMemo(() => {
+    let filtered = [...rawReservations];
+    
+    if (filters.roomId) {
+      const selectedRoomName = rooms.find(r => r.id === Number(filters.roomId))?.roomName;
+      if (selectedRoomName) {
+        filtered = filtered.filter(res => res.roomName === selectedRoomName);
+      }
+    }
+    if (filters.status) {
+      filtered = filtered.filter(res => res.status === filters.status);
+    }
+    if (filters.userName) {
+      filtered = filtered.filter(res => 
+        res.userName.toLowerCase().includes(filters.userName.toLowerCase())
+      );
+    }
+    return filtered;
+  }, [rawReservations, filters, rooms]);
+
   const handleDelete = async (reservationId: number) => {
     if (!confirm("정말 삭제하시겠습니까?")) return;
     try {
-      // 관리자용 삭제는 별도 API가 필요할 수 있습니다.
-      // 현재는 사용자용 API를 사용합니다.
-      alert("관리자용 삭제 기능은 별도 구현이 필요합니다.");
+      alert("관리자용 삭제 기능은 현재 API 연동이 필요합니다.");
     } catch (error: any) {
       alert(error.response?.data?.message || "삭제에 실패했습니다.");
     }
   };
 
-  if (loading) {
+  if (loading && rawReservations.length === 0) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <p>로딩 중...</p>
@@ -58,54 +99,102 @@ export default function AdminReservationsPage() {
         <main className="flex-1 w-full max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <h1 className="text-4xl font-black tracking-tight mb-8">예약 현황 관리</h1>
 
+          {/* Filtering Bar */}
+          <Card className="mb-8">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <Select
+                label="회의실 필터"
+                options={[
+                  { value: "", label: "전체 회의실" },
+                  ...rooms.map(room => ({ value: room.id.toString(), label: room.roomName }))
+                ]}
+                value={filters.roomId}
+                onChange={(e) => setFilters({ ...filters, roomId: e.target.value })}
+              />
+              <Select
+                label="상태 필터"
+                options={[
+                  { value: "", label: "전체 상태" },
+                  { value: "예약", label: "예약" },
+                  { value: "취소", label: "취소" },
+                  { value: "완료", label: "완료" },
+                ]}
+                value={filters.status}
+                onChange={(e) => setFilters({ ...filters, status: e.target.value })}
+              />
+              <Input
+                label="예약자 검색"
+                placeholder="이름을 입력하세요"
+                value={filters.userName}
+                onChange={(e) => setFilters({ ...filters, userName: e.target.value })}
+              />
+            </div>
+          </Card>
+
           <div className="flex flex-col gap-4 mb-8">
-            {reservations.length === 0 ? (
+            {filteredReservations.length === 0 ? (
               <Card>
-                <p className="text-center text-text-light-secondary dark:text-text-dark-secondary">
-                  예약 내역이 없습니다.
-                </p>
+                <div className="py-12 flex flex-col items-center justify-center text-text-light-secondary dark:text-dark-secondary">
+                  <span className="material-symbols-outlined text-4xl mb-2 opacity-20">event_busy</span>
+                  <p>조건에 맞는 예약 내역이 없습니다.</p>
+                </div>
               </Card>
             ) : (
-              reservations.map((reservation) => (
-                <Card key={reservation.id}>
-                  <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
-                    <div className="flex-1">
-                      <h3 className="text-lg font-bold mb-2">{reservation.roomName}</h3>
-                      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm text-text-light-secondary dark:text-text-dark-secondary">
-                        <p>
-                          <span className="font-semibold">강의:</span> {reservation.courseName}
+              filteredReservations.map((reservation) => (
+                <Card key={reservation.id} className="hover:shadow-md transition-shadow">
+                  <div className="flex flex-col lg:flex-row justify-between items-start lg:items-center gap-6">
+                    {/* Left: Time & Date Side Badge */}
+                    <div className="flex items-center gap-4 min-w-[150px]">
+                      <div className="flex flex-col items-center justify-center size-16 rounded-xl bg-primary/10 text-primary">
+                        <span className="text-xs font-bold">{new Date(reservation.reservationDate).getMonth() + 1}월</span>
+                        <span className="text-2xl font-black">{new Date(reservation.reservationDate).getDate()}일</span>
+                      </div>
+                      <div className="flex flex-col">
+                        <span className="text-sm font-bold text-gray-500">{new Date(reservation.reservationDate).toLocaleDateString("ko-KR", { weekday: 'short' })}요일</span>
+                        <span className="text-base font-black text-primary">
+                          {reservation.startTime.substring(0, 5)} - {reservation.endTime.substring(0, 5)}
+                        </span>
+                      </div>
+                    </div>
+
+                    {/* Middle: Content */}
+                    <div className="flex-1 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-y-4 gap-x-8 lg:max-w-2xl">
+                      <div className="min-w-[120px]">
+                        <p className="text-[10px] text-gray-400 font-medium mb-1">회의실</p>
+                        <p className="text-sm font-bold truncate">{reservation.roomName}</p>
+                      </div>
+                      <div className="min-w-[150px]">
+                        <p className="text-[10px] text-gray-400 font-medium mb-1">예약자 (강의)</p>
+                        <p className="text-sm font-bold truncate">
+                          {reservation.userName} <span className="text-xs font-normal text-gray-500">({reservation.courseName})</span>
                         </p>
-                        <p>
-                          <span className="font-semibold">예약자:</span> {reservation.userName}
-                        </p>
-                        <p>
-                          <span className="font-semibold">연락처:</span> {reservation.phoneLastNumber}
-                        </p>
-                        <p>
-                          <span className="font-semibold">상태:</span> {reservation.status}
-                        </p>
-                        <p>
-                          <span className="font-semibold">날짜:</span>{" "}
-                          {new Date(reservation.reservationDate).toLocaleDateString("ko-KR")}
-                        </p>
-                        <p>
-                          <span className="font-semibold">시간:</span>{" "}
-                          {reservation.startTime.split(":").slice(0, 2).join(":")} ~{" "}
-                          {reservation.endTime.split(":").slice(0, 2).join(":")}
-                        </p>
-                        <p>
-                          <span className="font-semibold">생성일:</span>{" "}
-                          {new Date(reservation.createdAt).toLocaleString("ko-KR")}
+                      </div>
+                      <div className="min-w-[100px]">
+                        <p className="text-[10px] text-gray-400 font-medium mb-1">연락처</p>
+                        <p className="text-sm font-bold">
+                          {reservation.userName === 'master' || !reservation.phoneLastNumber ? '-' : reservation.phoneLastNumber}
                         </p>
                       </div>
                     </div>
-                    <Button
-                      variant="secondary"
-                      onClick={() => handleDelete(reservation.id)}
-                      size="sm"
-                    >
-                      삭제
-                    </Button>
+
+                    {/* Right: Status & Action */}
+                    <div className="flex items-center gap-4 w-full lg:w-48 justify-between lg:justify-end border-t lg:border-t-0 pt-4 lg:pt-0">
+                      <span className={`px-3 py-1 rounded-full text-[11px] font-bold whitespace-nowrap ${
+                        reservation.status === '예약' ? 'bg-green-100 text-green-600' :
+                        reservation.status === '취소' ? 'bg-red-100 text-red-600' :
+                        'bg-gray-100 text-gray-600'
+                      }`}>
+                        {reservation.status}
+                      </span>
+                      <Button
+                        variant="secondary"
+                        onClick={() => handleDelete(reservation.id)}
+                        size="sm"
+                        className="text-red-500 hover:text-red-600 shrink-0"
+                      >
+                        삭제
+                      </Button>
+                    </div>
                   </div>
                 </Card>
               ))
@@ -121,7 +210,7 @@ export default function AdminReservationsPage() {
               >
                 이전
               </Button>
-              <span className="flex items-center px-4">
+              <span className="flex items-center px-4 text-sm font-medium">
                 {page} / {totalPages}
               </span>
               <Button
@@ -138,4 +227,3 @@ export default function AdminReservationsPage() {
     </AdminGuard>
   );
 }
-

--- a/app/rooms/reserve/page.tsx
+++ b/app/rooms/reserve/page.tsx
@@ -110,14 +110,15 @@ export default function ReservePage() {
     const paddedSeconds = s.toString().padStart(2, "0");
     return `${endHour.toString().padStart(2, "0")}:${endMinute
       .toString()
-      .padStart(2, "0")}:${paddedSeconds}`;
+      .padStart(2, "0")}:00`;
   };
 
-  const timeOptions = Array.from({ length: 20 }, (_, i) => {
-    const hour = 10 + i;
+  const timeOptions = Array.from({ length: 25 }, (_, i) => {
+    const hour = 10 + Math.floor(i / 2);
+    const minute = i % 2 === 0 ? "00" : "30";
     return {
-      value: `${hour.toString().padStart(2, "0")}:00:00`,
-      label: `${hour}:00`,
+      value: `${hour.toString().padStart(2, "0")}:${minute}:00`,
+      label: `${hour}:${minute}`,
     };
   });
 
@@ -223,7 +224,6 @@ export default function ReservePage() {
                   />
                 </div>
                 <Button type="submit" fullWidth disabled={loading}>
-                  <span className="material-symbols-outlined">event_available</span>
                   예약 확정하기
                 </Button>
               </form>


### PR DESCRIPTION
## 회의실 예약 페이지

### 수정 사항

- 예약 버튼 문구 및 UI 정보 수정
- 회의실 시작 시간 선택 드롭다운 범위 조정
    - 기존: 10시 ~ 29시 노출
    - 변경: 운영 시간 기준으로 정상 범위만 노출
- 회의실 예약이 30분 단위로 진행되므로
    - 시작 시간 또한 30분 단위로만 선택 가능하도록 수정
<img width="279" height="686" alt="image" src="https://github.com/user-attachments/assets/1a18cde2-a055-497f-9f2e-8a7e46758e35" />
<img width="292" height="72" alt="image" src="https://github.com/user-attachments/assets/4b7357ca-c2fc-4537-9219-d96d00c30a0d" />


---

## 회의실 현황 페이지

### 수정 사항

- 강사 피드백 기준에 따라 시간 슬롯 간 간격 조정
- 예약 정보 클릭시 팝업창에 예약 상세 정보 제공
<img width="1709" height="976" alt="image" src="https://github.com/user-attachments/assets/4cda5ed4-1fbc-4de4-aed0-c3f2e92182e5" />
<img width="1706" height="977" alt="image" src="https://github.com/user-attachments/assets/0bb54988-003b-43ff-be9d-7e35bddaacf8" />


---

## 예약 현황 관리 페이지

### 수정 사항
#### 해당 부분은 회의를 통해 결정했어야 했는데 수정하는 김에 한번에 해버리자 싶어서 일단 수정해 봤습니다. 혹시 이 전 페이지가 더 좋다고 판단되면 다시 수정해 놓을테니 자유롭게 의견주시면 감사할 거 같습니다.
- 가독성 향상을 위한 리팩터링
- 회의실 및 예악 상태별 필터링 기능 추가
- 예약자 이름을 통한 검색 기능 추가
<img width="708" height="588" alt="image" src="https://github.com/user-attachments/assets/550fbfdf-ed5f-4749-9cc9-9ea2a41289f8" />

- 기존
<img width="707" height="619" alt="image" src="https://github.com/user-attachments/assets/0476d135-f948-4030-898c-55704ff088ab" />

- 수정후




추가적인 의견이 있으면 카톡이나 코멘트로 자유롭게 남겨주세요
