### PR TITLE
feat/Admin : 관리자 생성 시 입력 값 검증 알림 출력

### DIFF
--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -47,7 +47,47 @@ export default function AdminUsersPage() {
       setNewAdmin({ userId: "", password: "", name: "", email: "" });
       fetchAdmins();
     } catch (error: any) {
-      alert(error.response?.data?.message || "관리자 추가에 실패했습니다.");
+      console.error("Signup Failed - Full Error Object:", error);
+      console.error("Signup Failed - Response Data:", error.response?.data);
+
+      const errorData = error.response?.data;
+      let errorMessage = "관리자 추가에 실패했습니다.";
+
+      if (errorData) {
+
+        if (Array.isArray(errorData.errors) && errorData.errors.length > 0) {
+          const firstError = errorData.errors[0];
+          errorMessage = firstError.defaultMessage || firstError.message || JSON.stringify(firstError);
+        }
+        else if (typeof errorData === "string") {
+          errorMessage = errorData;
+        }
+        else if (errorData.message) {
+          errorMessage = errorData.message;
+        }
+        // 4. Flat Map of Field Errors (e.g., { email: "Invalid...", password: "..." })
+        // Check if it's an object and take the first string value found
+        else if (typeof errorData === "object" && Object.keys(errorData).length > 0) {
+          // 우선순위에 따라 에러 메시지 확인
+          const priorityFields = ["userId", "password", "name", "email"];
+          for (const field of priorityFields) {
+            if (errorData[field]) {
+              errorMessage = errorData[field];
+              break;
+            }
+          }
+
+          // 우선순위 필드가 없으면 첫 번째 에러 메시지 사용
+          if (errorMessage === "관리자 추가에 실패했습니다.") {
+            const firstValue = Object.values(errorData)[0];
+            if (typeof firstValue === "string") {
+              errorMessage = firstValue;
+            }
+          }
+        }
+      }
+
+      alert(errorMessage);
     }
   };
 
@@ -124,35 +164,35 @@ export default function AdminUsersPage() {
             {admins
               .filter((admin) => admin.role !== "MASTER")
               .map((admin) => (
-              <Card key={admin.id}>
-                <div className="flex flex-col gap-4">
-                  <div className="flex items-center gap-3">
-                    <div className="flex-shrink-0 size-12 rounded-full overflow-hidden">
-                      <Image
-                        src="/logo.png"
-                        alt={`${admin.name} 프로필`}
-                        width={48}
-                        height={48}
-                        className="h-full w-full object-cover"
-                      />
+                <Card key={admin.id}>
+                  <div className="flex flex-col gap-4">
+                    <div className="flex items-center gap-3">
+                      <div className="flex-shrink-0 size-12 rounded-full overflow-hidden">
+                        <Image
+                          src="/logo.png"
+                          alt={`${admin.name} 프로필`}
+                          width={48}
+                          height={48}
+                          className="h-full w-full object-cover"
+                        />
+                      </div>
+                      <div className="flex-1">
+                        <h3 className="text-xl font-bold">{admin.name}</h3>
+                      </div>
                     </div>
-                    <div className="flex-1">
-                      <h3 className="text-xl font-bold">{admin.name}</h3>
+                    <div className="flex flex-col gap-1 text-sm text-text-light-secondary dark:text-text-dark-secondary">
+                      <p>ID: {admin.userId}</p>
+                      <p>이메일: {admin.email}</p>
+                      <p>역할: {admin.role}</p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button variant="secondary" onClick={() => handleDelete(admin.id)} size="sm">
+                        삭제
+                      </Button>
                     </div>
                   </div>
-                  <div className="flex flex-col gap-1 text-sm text-text-light-secondary dark:text-text-dark-secondary">
-                    <p>ID: {admin.userId}</p>
-                    <p>이메일: {admin.email}</p>
-                    <p>역할: {admin.role}</p>
-                  </div>
-                  <div className="flex gap-2">
-                    <Button variant="secondary" onClick={() => handleDelete(admin.id)} size="sm">
-                      삭제
-                    </Button>
-                  </div>
-                </div>
-              </Card>
-            ))}
+                </Card>
+              ))}
           </div>
         </main>
       </div>


### PR DESCRIPTION
## 관리자 추가(생성) 시 입력 값 검증 알림을 출력하는 코드를 작성

모든 필드 입력 값이 잘못 입력되었어도 순서대로 (ID -> 비밀번호 -> 이름 -> 이메일) 알림이 출력되도록 하였습니다.


### [ 프론트엔드 테스트 화면 ]

**1. ID 검증 알림**
<img width="1261" height="437" alt="스크린샷 2025-12-30 오전 11 08 27" src="https://github.com/user-attachments/assets/b0427248-c973-4509-846d-5085e5b95e97" />

<br>**2. 비밀번호 검증 알림**
<img width="1253" height="437" alt="스크린샷 2025-12-30 오전 11 08 40" src="https://github.com/user-attachments/assets/d01938ab-63d7-406c-a07f-44cda7f1a4e4" />

<br>**3. 이름 검증 알림**
<img width="1258" height="433" alt="스크린샷 2025-12-30 오전 11 08 54" src="https://github.com/user-attachments/assets/52f31530-c704-4be8-bd00-213e08937018" />

<br>**4. 이메일 검증 알림**
<img width="1248" height="433" alt="스크린샷 2025-12-30 오전 11 09 08" src="https://github.com/user-attachments/assets/664a2c38-d41d-43a5-9acb-2bf74b702a79" />

<br>**5. 모든 검증 통과 후 관리자 생성 시 알림**
<img width="1268" height="440" alt="스크린샷 2025-12-30 오전 11 09 24" src="https://github.com/user-attachments/assets/13a6f066-97ad-45c3-870d-7aba882bb09f" />

<br>**6. 관리자 생성 성공**
<img width="1275" height="670" alt="스크린샷 2025-12-30 오전 11 09 34" src="https://github.com/user-attachments/assets/bd4b6f62-1906-432b-81fd-f9927890c212" />

<br>**7. DB 추가 화면**
<img width="1296" height="155" alt="스크린샷 2025-12-30 오전 11 10 10" src="https://github.com/user-attachments/assets/e2da7ea1-f130-4891-a8ca-decb1c168526" />



<br>
<br>

Closes #17 