### PR TITLE
UI/UX수정

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -73,7 +73,7 @@ export default function HomePage() {
                   {/* 사용자 가이드 버튼 */}
                   <a
                     className="group flex items-center gap-2 rounded-full bg-primary/10 px-6 py-2.5 text-sm font-bold text-primary transition-all hover:bg-primary/20 hover:scale-105 active:scale-95"
-                    href="#" // TODO: 노션 링크로 교체 필요
+                    href="https://ringed-room-6d9.notion.site/2dbff06ad20f806e93f2dd4a6ed8b196?source=copy_link"
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/app/rooms/monitor/page.tsx
+++ b/app/rooms/monitor/page.tsx
@@ -51,9 +51,9 @@ export default function RoomMonitorPage() {
 
   const getTimePosition = (time: string) => {
     const [hours, minutes] = time.split(":").map(Number);
-    // 9시부터 23시까지 총 14시간 기준 (28개 슬롯)
-    const totalMinutesFromStart = (hours - 9) * 60 + minutes;
-    const totalGridMinutes = 14 * 60;
+    // 10시부터 22시까지 총 12시간 기준
+    const totalMinutesFromStart = (hours - 10) * 60 + minutes;
+    const totalGridMinutes = 12 * 60;
     return (totalMinutesFromStart / totalGridMinutes) * 100;
   };
 
@@ -61,7 +61,7 @@ export default function RoomMonitorPage() {
     const [startH, startM] = startTime.split(":").map(Number);
     const [endH, endM] = endTime.split(":").map(Number);
     const durationMinutes = (endH * 60 + endM) - (startH * 60 + startM);
-    const totalGridMinutes = 14 * 60;
+    const totalGridMinutes = 12 * 60;
     return (durationMinutes / totalGridMinutes) * 100;
   };
 
@@ -108,13 +108,13 @@ export default function RoomMonitorPage() {
                   </div>
 
                   {/* Table Body (Time & Content) */}
-                  <div className="flex relative h-[840px]"> {/* 14시간 * 60px = 840px */}
+                  <div className="flex relative h-[720px]"> {/* 12시간 * 60px = 720px */}
                     
                     {/* Time Column (Left Sidebar) */}
                     <div className="sticky left-0 z-30 w-16 bg-white dark:bg-background-dark border-r border-border-light dark:border-border-dark flex-shrink-0 flex flex-col">
-                      {Array.from({ length: 14 }, (_, i) => (
+                      {Array.from({ length: 12 }, (_, i) => (
                         <div key={i} className="flex-1 border-b border-border-light/30 dark:border-border-dark/30 text-xs text-text-light-secondary dark:text-dark-secondary font-medium flex items-start justify-center pt-2">
-                          {9 + i}:00
+                          {10 + i}:00
                         </div>
                       ))}
                     </div>
@@ -123,7 +123,7 @@ export default function RoomMonitorPage() {
                     <div className="flex flex-1 relative">
                       {/* Background Grid Lines (Horizontal) */}
                       <div className="absolute inset-0 flex flex-col z-0 pointer-events-none">
-                         {Array.from({ length: 14 }, (_, i) => (
+                         {Array.from({ length: 12 }, (_, i) => (
                            <div key={i} className="flex-1 border-b border-border-light/30 dark:border-border-dark/30" />
                          ))}
                       </div>

--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -58,9 +58,9 @@ export default function RoomsPage() {
 
   const getTimePosition = (time: string) => {
     const [hours, minutes] = time.split(":").map(Number);
-    // 9시부터 23시까지 총 14시간 기준 (28개 슬롯)
-    const totalMinutesFromStart = (hours - 9) * 60 + minutes;
-    const totalGridMinutes = 14 * 60;
+    // 10시부터 22시까지 총 12시간 기준
+    const totalMinutesFromStart = (hours - 10) * 60 + minutes;
+    const totalGridMinutes = 12 * 60;
     return (totalMinutesFromStart / totalGridMinutes) * 100;
   };
 
@@ -68,7 +68,7 @@ export default function RoomsPage() {
     const [startH, startM] = startTime.split(":").map(Number);
     const [endH, endM] = endTime.split(":").map(Number);
     const durationMinutes = (endH * 60 + endM) - (startH * 60 + startM);
-    const totalGridMinutes = 14 * 60;
+    const totalGridMinutes = 12 * 60;
     return (durationMinutes / totalGridMinutes) * 100;
   };
 
@@ -125,13 +125,13 @@ export default function RoomsPage() {
                   </div>
 
                   {/* Table Body (Time & Content) */}
-                  <div className="flex relative h-[840px]"> {/* 14시간 * 60px = 840px */}
+                  <div className="flex relative h-[720px]"> {/* 12시간 * 60px = 720px */}
                     
                     {/* Time Column (Left Sidebar) */}
                     <div className="sticky left-0 z-30 w-16 bg-white dark:bg-background-dark border-r border-border-light dark:border-border-dark flex-shrink-0 flex flex-col">
-                      {Array.from({ length: 14 }, (_, i) => (
+                      {Array.from({ length: 12 }, (_, i) => (
                         <div key={i} className="flex-1 border-b border-border-light/30 dark:border-border-dark/30 text-xs text-text-light-secondary dark:text-dark-secondary font-medium flex items-start justify-center pt-2">
-                          {9 + i}:00
+                          {10 + i}:00
                         </div>
                       ))}
                     </div>
@@ -140,7 +140,7 @@ export default function RoomsPage() {
                     <div className="flex flex-1 relative">
                       {/* Background Grid Lines (Horizontal) */}
                       <div className="absolute inset-0 flex flex-col z-0 pointer-events-none">
-                         {Array.from({ length: 14 }, (_, i) => (
+                         {Array.from({ length: 12 }, (_, i) => (
                            <div key={i} className="flex-1 border-b border-border-light/30 dark:border-border-dark/30" />
                          ))}
                       </div>


### PR DESCRIPTION
- 사용자 회의실 예약시 날짜는 현재일, 익일 2일만 선택 가능 ( 관리자는 제한 x )
<img width="272" height="349" alt="image" src="https://github.com/user-attachments/assets/6af4efaf-88b5-40ba-9e22-66f1225c6cda" />

- 관리자가 회의실 예약시 이용시간 제약 (2시간) 없이 예약 가능
<img width="926" height="116" alt="image" src="https://github.com/user-attachments/assets/7f474acd-03c6-4e51-85b6-569b8ba530e1" />

- 회의실 현황 페이지 9시 ~ 23시로 표시까지 표가 만들어져 있었는데 , 10시 ~ 22시까지 표가 보여지도록 변경
<img width="905" height="782" alt="image" src="https://github.com/user-attachments/assets/ec34027a-76d9-4a6c-a20f-33159dc5a119" />


- 사용자 가이드 Notion 연결