### PR TITLE
달력 부분을 한국 시간에 맞게 수정

### DIFF
--- a/app/rooms/monitor/page.tsx
+++ b/app/rooms/monitor/page.tsx
@@ -4,13 +4,14 @@ import { useState, useEffect } from "react";
 import Image from "next/image";
 import { roomApi } from "@/lib/api/room";
 import { reservationApi } from "@/lib/api/reservation";
+import { getTodayDate } from "@/lib/utils/date";
 import type { RoomResponse, ReservationResponse } from "@/types";
 
 export default function RoomMonitorPage() {
   const [rooms, setRooms] = useState<RoomResponse[]>([]);
   // 항상 오늘 날짜로 고정
   const [selectedDate] = useState<string>(
-    new Date().toISOString().split("T")[0]
+    getTodayDate()
   );
   const [reservations, setReservations] = useState<Record<number, ReservationResponse[]>>({});
   const [loading, setLoading] = useState(true);

--- a/app/rooms/page.tsx
+++ b/app/rooms/page.tsx
@@ -4,13 +4,14 @@ import { useState, useEffect } from "react";
 import Header from "@/components/common/Header";
 import { roomApi } from "@/lib/api/room";
 import { reservationApi } from "@/lib/api/reservation";
+import { getTodayDate } from "@/lib/utils/date";
 import type { RoomResponse, ReservationResponse } from "@/types";
 import Link from "next/link";
 
 export default function RoomsPage() {
   const [rooms, setRooms] = useState<RoomResponse[]>([]);
   const [selectedDate, setSelectedDate] = useState<string>(
-    new Date().toISOString().split("T")[0]
+    getTodayDate()
   );
   const [reservations, setReservations] = useState<Record<number, ReservationResponse[]>>({});
   const [loading, setLoading] = useState(true);

--- a/app/rooms/reserve/page.tsx
+++ b/app/rooms/reserve/page.tsx
@@ -11,6 +11,7 @@ import { roomApi } from "@/lib/api/room";
 import { courseApi } from "@/lib/api/course";
 import { reservationApi } from "@/lib/api/reservation";
 import { getDecodedToken, isAdmin } from "@/lib/utils/jwt";
+import { getTodayDate } from "@/lib/utils/date";
 import type { RoomResponse, CourseResponse, ReservationRequest, AdminReservationRequest } from "@/types";
 
 function ReserveContent() {
@@ -54,7 +55,7 @@ function ReserveContent() {
     return `${hours.toString().padStart(2, "0")}:${minutes.toString().padStart(2, "0")}:00`;
   };
 
-  const today = new Date().toISOString().split("T")[0];
+  const today = getTodayDate();
   const [selectedDate, setSelectedDate] = useState<string>(today);
   
   // 시작 시간을 시와 분으로 분리
@@ -311,7 +312,10 @@ function ReserveContent() {
                         onClick={() => {
                           const tomorrowDate = new Date();
                           tomorrowDate.setDate(tomorrowDate.getDate() + 1);
-                          const tomorrow = tomorrowDate.toISOString().split("T")[0];
+                          const year = tomorrowDate.getFullYear();
+                          const month = String(tomorrowDate.getMonth() + 1).padStart(2, '0');
+                          const day = String(tomorrowDate.getDate()).padStart(2, '0');
+                          const tomorrow = `${year}-${month}-${day}`;
                           
                           setSelectedDate(tomorrow);
                           setStartHour(9);
@@ -326,7 +330,10 @@ function ReserveContent() {
                         {(() => {
                           const tomorrowDate = new Date();
                           tomorrowDate.setDate(tomorrowDate.getDate() + 1);
-                          return `${tomorrowDate.toISOString().split("T")[0]} (명일)`;
+                          const year = tomorrowDate.getFullYear();
+                          const month = String(tomorrowDate.getMonth() + 1).padStart(2, '0');
+                          const day = String(tomorrowDate.getDate()).padStart(2, '0');
+                          return `${year}-${month}-${day} (명일)`;
                         })()}
                       </button>
                     </div>

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -21,7 +21,11 @@ export const formatTime = (timeString: string): string => {
 };
 
 export const getTodayDate = (): string => {
-  return new Date().toISOString().split("T")[0];
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 };
 
 export const getWeekday = (dateString: string): string => {


### PR DESCRIPTION
기존엔 utc 기준으로 날짜를 가져왔습니다. 즉 오전 9시 전에 접속을 하면 전날 날짜가 달력이 출력이 되는 것을 확인할 수 있었습니다. 로컬 시간(웹 브라우저)을 가져오는 방향으로 개선하였습니다.